### PR TITLE
Refactor file reader service to handle multiple files

### DIFF
--- a/src/main/java/org/graylog/collector/file/ChunkBufferStore.java
+++ b/src/main/java/org/graylog/collector/file/ChunkBufferStore.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.file;
+
+import com.google.common.collect.Maps;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Stores {@link ByteBuf} chunks for a path. It appends new buffers to existing ones.
+ *
+ * This class is thread-safe.
+ */
+public class ChunkBufferStore {
+    private final Map<Path, ByteBuf> buffersPerFile = Maps.newHashMap();
+
+    public ChunkBufferStore() {
+    }
+
+    /**
+     * Returns the {@link ByteBuf} for the given path, null if there is no buffer for the path.
+     *
+     * @param path the path
+     * @return the buffer for the given path or null
+     */
+    public synchronized ByteBuf get(final Path path) {
+        return buffersPerFile.get(path);
+    }
+
+    /**
+     * Stores the {@link ByteBuf} for the given path. If there is a buffer for the path already, the new buffer
+     * will be appended to the existing one.
+     *
+     * @param path the path
+     * @param chunk the buffer
+     */
+    public synchronized void put(final Path path, final ByteBuf chunk) {
+        final ByteBuf buf = get(path);
+
+        if (buf == null) {
+            buffersPerFile.put(path, chunk);
+        } else {
+            buffersPerFile.put(path, Unpooled.wrappedBuffer(buf, chunk));
+        }
+    }
+}

--- a/src/main/java/org/graylog/collector/file/ChunkReader.java
+++ b/src/main/java/org/graylog/collector/file/ChunkReader.java
@@ -161,4 +161,24 @@ public class ChunkReader implements Runnable {
             locked.set(false);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ChunkReader that = (ChunkReader) o;
+
+        if (!fileInput.equals(that.fileInput)) return false;
+        return path.equals(that.path);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = fileInput.hashCode();
+        result = 31 * result + path.hashCode();
+        return result;
+    }
+
 }

--- a/src/main/java/org/graylog/collector/file/ChunkReaderScheduler.java
+++ b/src/main/java/org/graylog/collector/file/ChunkReaderScheduler.java
@@ -1,0 +1,98 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.file;
+
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.graylog.collector.inputs.Input;
+import org.graylog.collector.inputs.file.FileInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class ChunkReaderScheduler {
+    private static final Logger log = LoggerFactory.getLogger(ChunkReaderScheduler.class);
+
+    private final Input input;
+    private final int readerBufferSize;
+    private final long readerInterval;
+    private final boolean followMode;
+    private final FileInput.InitialReadPosition initialReadPosition;
+    private final ArrayBlockingQueue<FileChunk> chunkQueue;
+    private final Map<Path, ChunkReader> chunkReaders = Maps.newHashMap();
+    private final Map<Path, ScheduledFuture<?>> chunkReaderFutures = Maps.newHashMap();
+    private final ScheduledExecutorService scheduler;
+
+    public ChunkReaderScheduler(final Input input,
+                                final ArrayBlockingQueue<FileChunk> chunkQueue,
+                                final int readerBufferSize,
+                                final long readerInterval,
+                                final boolean followMode,
+                                final FileInput.InitialReadPosition initialReadPosition) {
+        this.input = input;
+        this.chunkQueue = chunkQueue;
+        this.readerBufferSize = readerBufferSize;
+        this.readerInterval = readerInterval;
+        this.followMode = followMode;
+        this.initialReadPosition = initialReadPosition;
+
+        // TODO Make the thread size configurable.
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder()
+                        .setDaemon(false)
+                        .setNameFormat("chunkreader-scheduler-thread-%d")
+                        .build());
+    }
+
+    public synchronized boolean isFollowingFile(Path file) {
+        // TODO if there is a chunkreader already, check the fileKey of the underlying file
+        return chunkReaders.containsKey(file) && chunkReaderFutures.containsKey(file);
+    }
+
+    public synchronized void followFile(Path file) throws IOException {
+        final AsynchronousFileChannel fileChannel = AsynchronousFileChannel.open(file, StandardOpenOption.READ);
+        final ChunkReader chunkReader = new ChunkReader(input, file, fileChannel, chunkQueue, readerBufferSize, followMode, initialReadPosition);
+        final ScheduledFuture<?> chunkReaderFuture = scheduler.scheduleAtFixedRate(chunkReader, 0, readerInterval, TimeUnit.MILLISECONDS);
+
+        log.debug("Following file {}", file);
+
+        chunkReaders.put(file, chunkReader);
+        chunkReaderFutures.put(file, chunkReaderFuture);
+    }
+
+    public synchronized void cancelFile(Path file) {
+        final ScheduledFuture<?> future = chunkReaderFutures.remove(file);
+
+        if (future != null) {
+            log.debug("Cancel file {}", file);
+
+            future.cancel(false);
+        }
+
+        chunkReaders.remove(file);
+    }
+}

--- a/src/main/java/org/graylog/collector/file/naming/NumberSuffixStrategy.java
+++ b/src/main/java/org/graylog/collector/file/naming/NumberSuffixStrategy.java
@@ -16,39 +16,61 @@
  */
 package org.graylog.collector.file.naming;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.Nullable;
 import java.nio.file.Path;
+import java.util.Set;
 
 public class NumberSuffixStrategy implements FileNamingStrategy {
 
-    private final Path basePath;
+    private final Iterable<Path> basePaths;
 
     public NumberSuffixStrategy(Path basePath) {
-        this.basePath = basePath.normalize();
+        this(ImmutableSet.of(basePath));
+    }
+
+    public NumberSuffixStrategy(Set<Path> basePaths) {
+        this.basePaths = Iterables.transform(basePaths, new Function<Path, Path>() {
+            @Nullable
+            @Override
+            public Path apply(Path path) {
+                return path.normalize().toAbsolutePath();
+            }
+        });
     }
 
     @Override
-    public boolean pathMatches(Path path) {
-        path = path.normalize();
-        path = basePath.getParent().resolve(path);
-        // only allow files in the same directory
-        if (!basePath.getParent().equals(path.getParent())) {
-            return false;
-        }
-        final String filename = path.getFileName().toString();
-        final String baseFilename = this.basePath.getFileName().toString();
+    public boolean pathMatches(final Path path) {
+        return Iterables.any(basePaths, new Predicate<Path>() {
+            @Override
+            public boolean apply(@Nullable Path basePath) {
+                Path normalizedPath = path.normalize();
+                normalizedPath = basePath.getParent().resolve(normalizedPath);
+                // only allow files in the same directory
+                if (!basePath.getParent().equals(normalizedPath.getParent())) {
+                    return false;
+                }
+                final String filename = normalizedPath.getFileName().toString();
+                final String baseFilename = basePath.getFileName().toString();
 
-        // same files are a match
-        if (filename.equals(baseFilename)) {
-            return true;
-        }
+                // same files are a match
+                if (filename.equals(baseFilename)) {
+                    return true;
+                }
 
-        // do the files have a common beginning? if not, they aren't related.
-        if (!filename.startsWith(baseFilename)) {
-            return false;
-        }
+                // do the files have a common beginning? if not, they aren't related.
+                if (!filename.startsWith(baseFilename)) {
+                    return false;
+                }
 
-        // check for number suffix
-        final String onlySuffix = filename.substring(baseFilename.length());
-        return onlySuffix.matches("^\\.\\d+$");
+                // check for number suffix
+                final String onlySuffix = filename.substring(baseFilename.length());
+                return onlySuffix.matches("^\\.\\d+$");
+            }
+        });
     }
 }

--- a/src/main/java/org/graylog/collector/inputs/InputConfiguration.java
+++ b/src/main/java/org/graylog/collector/inputs/InputConfiguration.java
@@ -68,4 +68,20 @@ public abstract class InputConfiguration implements Configuration {
             }
         });
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InputConfiguration that = (InputConfiguration) o;
+
+        return id.equals(that.id);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
 }

--- a/src/main/java/org/graylog/collector/inputs/file/FileInput.java
+++ b/src/main/java/org/graylog/collector/inputs/file/FileInput.java
@@ -102,6 +102,22 @@ public class FileInput extends InputService {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FileInput fileInput = (FileInput) o;
+
+        return configuration.equals(fileInput.configuration);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return configuration.hashCode();
+    }
+
+    @Override
     public String toString() {
         return ConfigurationUtils.toString(configuration, this);
     }

--- a/src/main/java/org/graylog/collector/inputs/file/FileInput.java
+++ b/src/main/java/org/graylog/collector/inputs/file/FileInput.java
@@ -16,11 +16,13 @@
  */
 package org.graylog.collector.inputs.file;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.collector.MessageBuilder;
 import org.graylog.collector.buffer.Buffer;
 import org.graylog.collector.config.ConfigurationUtils;
 import org.graylog.collector.file.ChunkReader;
+import org.graylog.collector.file.FileObserver;
 import org.graylog.collector.file.FileReaderService;
 import org.graylog.collector.file.naming.NumberSuffixStrategy;
 import org.graylog.collector.inputs.InputService;
@@ -67,12 +69,14 @@ public class FileInput extends InputService {
 
     @Override
     protected void run() throws Exception {
-        final Path path = configuration.getPath().toPath();
+        // TODO needs to be an absolute path because otherwise the FileObserver does weird things. Investigate what's wrong with it.
+        final Path path = configuration.getPath().toPath().toAbsolutePath();
         final MessageBuilder messageBuilder = new MessageBuilder().input(getId()).outputs(getOutputs()).source(Utils.getHostname());
+        final ImmutableSet<Path> paths = ImmutableSet.of(path);
         final FileReaderService readerService = new FileReaderService(
-                path,
+                paths,
                 configuration.getCharset(),
-                new NumberSuffixStrategy(path),
+                new NumberSuffixStrategy(paths),
                 true,
                 InitialReadPosition.END,
                 this,
@@ -80,7 +84,8 @@ public class FileInput extends InputService {
                 configuration.createContentSplitter(),
                 buffer,
                 configuration.getReaderBufferSize(),
-                configuration.getReaderInterval()
+                configuration.getReaderInterval(),
+                new FileObserver()
         );
 
         readerService.startAsync();

--- a/src/test/java/org/graylog/collector/file/ChunkBufferStoreTest.java
+++ b/src/test/java/org/graylog/collector/file/ChunkBufferStoreTest.java
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.file;
+
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ChunkBufferStoreTest {
+    @Test
+    public void test() throws Exception {
+        final ChunkBufferStore store = new ChunkBufferStore();
+        final Path path1 = Paths.get("/tmp/foo-1.log");
+        final Path path2 = Paths.get("/tmp/foo-2.log");
+
+        assertNull("Empty store should not have any buffers...", store.get(path1));
+        assertNull("Empty store should not have any buffers...", store.get(path2));
+
+        store.put(path1, Unpooled.copiedBuffer("log 1\n".getBytes()));
+        assertEquals("Buffer should have correct data", "log 1\n", store.get(path1).toString(UTF_8));
+
+        store.put(path2, Unpooled.copiedBuffer("hello\n".getBytes()));
+        assertEquals("Buffer should have correct data", "hello\n", store.get(path2).toString(UTF_8));
+
+        store.put(path1, Unpooled.copiedBuffer("log 2\n".getBytes()));
+        assertEquals("New data should be appended to buffer", "log 1\nlog 2\n", store.get(path1).toString(UTF_8));
+
+        store.get(path1).readBytes(new byte[store.get(path1).readableBytes()]);
+        store.put(path1, Unpooled.copiedBuffer("new log\n".getBytes()));
+        assertEquals("Writing to truncated buffer should only have new data", "new log\n", store.get(path1).toString(UTF_8));
+
+        store.get(path2).readBytes(new byte[3], 0, 3);
+        store.put(path2, Unpooled.copiedBuffer("new log\n".getBytes()));
+        assertEquals("Buffer should have rest of old and the new data", "lo\nnew log\n", store.get(path2).toString(UTF_8));
+    }
+}

--- a/src/test/java/org/graylog/collector/file/FileObserverTest.java
+++ b/src/test/java/org/graylog/collector/file/FileObserverTest.java
@@ -1,0 +1,314 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.collector.file;
+
+import org.graylog.collector.file.naming.ExactFileStrategy;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+public class FileObserverTest {
+    private static final Logger log = LoggerFactory.getLogger(FileObserverTest.class);
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder temporaryFolder2 = new TemporaryFolder();
+
+    @Test
+    public void testObserverCallbacks() throws Exception {
+        final FileObserver fileObserver = new FileObserver();
+        final File file = temporaryFolder.newFile();
+        final Path path = file.toPath();
+        // make sure the file doesn't exist prior to this test
+        Files.deleteIfExists(path);
+
+        final CountDownLatch createLatch = new CountDownLatch(1);
+        final CountDownLatch deleteLatch = new CountDownLatch(1);
+        final CountDownLatch modifiedLatch = new CountDownLatch(1);
+
+        final FileObserver.Listener listener = new FileObserver.Listener() {
+            @Override
+            public void pathCreated(Path path) {
+                log.info("Path created {}", path);
+                createLatch.countDown();
+            }
+
+            @Override
+            public void pathRemoved(Path path) {
+                log.info("Path removed {}", path);
+                deleteLatch.countDown();
+            }
+
+            @Override
+            public void pathModified(Path path) {
+                log.info("Path modified {}", path);
+                modifiedLatch.countDown();
+            }
+
+            @Override
+            public void cannotObservePath(Path path) {
+                log.info("Cannot observe {}", path);
+            }
+        };
+
+        fileObserver.observePath(listener, path, new ExactFileStrategy(path));
+
+        fileObserver.startAsync();
+        fileObserver.awaitRunning(1, TimeUnit.MINUTES);
+
+        final boolean newFile = file.createNewFile();
+        log.debug("Created new file {} with key {}", file.getPath(),
+                Files.readAttributes(path, BasicFileAttributes.class).fileKey());
+        assertTrue("Created monitored file", newFile);
+
+        // OS X is using a poll service here, the default poll frequency is 10s (we set it to 2, but that's platform specific)
+        final boolean awaitCreate = createLatch.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored creation change event must be delivered.", awaitCreate);
+
+        Files.write(path, "hello".getBytes());
+        final boolean awaitModify = modifiedLatch.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored modification change event must be delivered.", awaitModify);
+
+        assertTrue("Must be able to remove log file", file.delete());
+        final boolean awaitRemove = deleteLatch.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored removal change event must be delivered.", awaitRemove);
+
+        fileObserver.stopAsync();
+        fileObserver.awaitTerminated(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void testObserverCallbacksForMultipleFiles() throws Exception {
+        final FileObserver fileObserver = new FileObserver();
+        final File file1 = temporaryFolder.newFile();
+        final File file2 = temporaryFolder.newFile();
+        final File file3 = temporaryFolder2.newFile();
+        final Path path1 = file1.toPath();
+        final Path path2 = file2.toPath();
+        final Path path3 = file3.toPath();
+        // make sure the file doesn't exist prior to this test
+        Files.deleteIfExists(path1);
+        Files.deleteIfExists(path2);
+        Files.deleteIfExists(path3);
+
+        final CountDownLatch createLatch1 = new CountDownLatch(1);
+        final CountDownLatch createLatch2 = new CountDownLatch(1);
+        final CountDownLatch createLatch3 = new CountDownLatch(1);
+        final CountDownLatch deleteLatch1 = new CountDownLatch(1);
+        final CountDownLatch deleteLatch2 = new CountDownLatch(1);
+        final CountDownLatch deleteLatch3 = new CountDownLatch(1);
+        final CountDownLatch modifiedLatch1 = new CountDownLatch(1);
+        final CountDownLatch modifiedLatch2 = new CountDownLatch(1);
+        final CountDownLatch modifiedLatch3 = new CountDownLatch(1);
+
+        final FileObserver.Listener listener = new FileObserver.Listener() {
+            @Override
+            public void pathCreated(Path path) {
+                log.info("Path created {}", path);
+                if (path.equals(path1)) {
+                    createLatch1.countDown();
+                } else if (path.equals(path2)) {
+                    createLatch2.countDown();
+                } else if (path.equals(path3)) {
+                    createLatch3.countDown();
+                }
+            }
+
+            @Override
+            public void pathRemoved(Path path) {
+                log.info("Path removed {}", path);
+                if (path.equals(path1)) {
+                    deleteLatch1.countDown();
+                } else if (path.equals(path2)) {
+                    deleteLatch2.countDown();
+                } else if (path.equals(path3)) {
+                    deleteLatch3.countDown();
+                }
+            }
+
+            @Override
+            public void pathModified(Path path) {
+                log.info("Path modified {}", path);
+                if (path.equals(path1)) {
+                    modifiedLatch1.countDown();
+                } else if (path.equals(path2)) {
+                    modifiedLatch2.countDown();
+                } else if (path.equals(path3)) {
+                    modifiedLatch3.countDown();
+                }
+            }
+
+            @Override
+            public void cannotObservePath(Path path) {
+                log.info("Cannot observe {}", path);
+            }
+        };
+
+        fileObserver.observePath(listener, path1, new ExactFileStrategy(path1));
+        fileObserver.observePath(listener, path2, new ExactFileStrategy(path2));
+        fileObserver.observePath(listener, path3, new ExactFileStrategy(path3));
+
+        fileObserver.startAsync();
+        fileObserver.awaitRunning(1, TimeUnit.MINUTES);
+
+        final boolean newFile1 = file1.createNewFile();
+        final boolean newFile2 = file2.createNewFile();
+        final boolean newFile3 = file3.createNewFile();
+        log.debug("Created new file {} with key {}", file1.getPath(), Files.readAttributes(path1, BasicFileAttributes.class).fileKey());
+        log.debug("Created new file {} with key {}", file2.getPath(), Files.readAttributes(path2, BasicFileAttributes.class).fileKey());
+        log.debug("Created new file {} with key {}", file3.getPath(), Files.readAttributes(path3, BasicFileAttributes.class).fileKey());
+        assertTrue("Created monitored file", newFile1);
+        assertTrue("Created monitored file", newFile2);
+        assertTrue("Created monitored file", newFile3);
+
+        // OS X is using a poll service here, the default poll frequency is 10s (we set it to 2, but that's platform specific)
+        final boolean awaitCreate1 = createLatch1.await(10, TimeUnit.SECONDS);
+        final boolean awaitCreate2 = createLatch2.await(10, TimeUnit.SECONDS);
+        final boolean awaitCreate3 = createLatch3.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored creation change event must be delivered.", awaitCreate1);
+        assertTrue("Monitored creation change event must be delivered.", awaitCreate2);
+        assertTrue("Monitored creation change event must be delivered.", awaitCreate3);
+
+        Files.write(path1, "hello1".getBytes());
+        Files.write(path2, "hello2".getBytes());
+        Files.write(path3, "hello3".getBytes());
+        final boolean awaitModify1 = modifiedLatch1.await(10, TimeUnit.SECONDS);
+        final boolean awaitModify2 = modifiedLatch2.await(10, TimeUnit.SECONDS);
+        final boolean awaitModify3 = modifiedLatch3.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored modification change event must be delivered.", awaitModify1);
+        assertTrue("Monitored modification change event must be delivered.", awaitModify2);
+        assertTrue("Monitored modification change event must be delivered.", awaitModify3);
+
+        assertTrue("Must be able to remove log file", file1.delete());
+        assertTrue("Must be able to remove log file", file2.delete());
+        assertTrue("Must be able to remove log file", file3.delete());
+        final boolean awaitRemove1 = deleteLatch1.await(10, TimeUnit.SECONDS);
+        final boolean awaitRemove2 = deleteLatch2.await(10, TimeUnit.SECONDS);
+        final boolean awaitRemove3 = deleteLatch3.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored removal change event must be delivered.", awaitRemove1);
+        assertTrue("Monitored removal change event must be delivered.", awaitRemove2);
+        assertTrue("Monitored removal change event must be delivered.", awaitRemove3);
+
+        fileObserver.stopAsync();
+        fileObserver.awaitTerminated(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void testNamingStrategy() throws Exception {
+        final FileObserver fileObserver = new FileObserver();
+        final File file1 = temporaryFolder.newFile();
+        final File file2 = temporaryFolder.newFile();
+        final Path path1 = file1.toPath();
+        final Path path2 = file2.toPath();
+        // make sure the file doesn't exist prior to this test
+        Files.deleteIfExists(path1);
+        Files.deleteIfExists(path2);
+
+        final CountDownLatch createLatch = new CountDownLatch(1);
+        final CountDownLatch deleteLatch = new CountDownLatch(1);
+        final CountDownLatch modifyLatch = new CountDownLatch(1);
+
+        final AtomicInteger createCountPath1 = new AtomicInteger(0);
+        final AtomicInteger deleteCountPath1 = new AtomicInteger(0);
+        final AtomicInteger modifyCountPath1 = new AtomicInteger(0);
+
+        final FileObserver.Listener listener = new FileObserver.Listener() {
+            @Override
+            public void pathCreated(Path path) {
+                log.info("Path created {}", path);
+                if (path.equals(path1)) {
+                    createCountPath1.incrementAndGet();
+                } else if (path.equals(path2)) {
+                    createLatch.countDown();
+                }
+            }
+
+            @Override
+            public void pathRemoved(Path path) {
+                log.info("Path removed {}", path);
+                if (path.equals(path1)) {
+                    deleteCountPath1.incrementAndGet();
+                } else if (path.equals(path2)) {
+                    deleteLatch.countDown();
+                }
+            }
+
+            @Override
+            public void pathModified(Path path) {
+                log.info("Path modified {}", path);
+                if (path.equals(path1)) {
+                    modifyCountPath1.incrementAndGet();
+                } else if (path.equals(path2)) {
+                    modifyLatch.countDown();
+                }
+            }
+
+            @Override
+            public void cannotObservePath(Path path) {
+                log.info("Cannot observe {}", path);
+            }
+        };
+
+        // Make sure to use a non-existent path for the naming strategy here!
+        fileObserver.observePath(listener, path1, new ExactFileStrategy(Paths.get("/tmp/foo/bar/baz")));
+        fileObserver.observePath(listener, path2, new ExactFileStrategy(path2));
+
+        fileObserver.startAsync();
+        fileObserver.awaitRunning(1, TimeUnit.MINUTES);
+
+        final boolean newFile1 = file1.createNewFile();
+        final boolean newFile2 = file2.createNewFile();
+        log.debug("Created new file {} with key {}", file1.getPath(), Files.readAttributes(path1, BasicFileAttributes.class).fileKey());
+        log.debug("Created new file {} with key {}", file2.getPath(), Files.readAttributes(path2, BasicFileAttributes.class).fileKey());
+        assertTrue("Created monitored file", newFile1);
+        assertTrue("Created monitored file", newFile2);
+
+        // OS X is using a poll service here, the default poll frequency is 10s (we set it to 2, but that's platform specific)
+        final boolean awaitCreate1 = createLatch.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored creation change event must be delivered.", awaitCreate1);
+        assertTrue("Monitored creation change event must NOT be delivered.", createCountPath1.get() == 0);
+
+        Files.write(path1, "hello1".getBytes());
+        Files.write(path2, "hello2".getBytes());
+        final boolean awaitModify1 = modifyLatch.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored modification change event must be delivered.", awaitModify1);
+        assertTrue("Monitored modification change event must NOT be delivered.", modifyCountPath1.get() == 0);
+
+        assertTrue("Must be able to remove log file", file1.delete());
+        assertTrue("Must be able to remove log file", file2.delete());
+        final boolean awaitRemove1 = deleteLatch.await(10, TimeUnit.SECONDS);
+        assertTrue("Monitored removal change event must be delivered.", awaitRemove1);
+        assertTrue("Monitored removal change event must NOT be delivered.", deleteCountPath1.get() == 0);
+
+        fileObserver.stopAsync();
+        fileObserver.awaitTerminated(1, TimeUnit.MINUTES);
+    }
+}


### PR DESCRIPTION
Lots of refactoring to make it possible to follow multiple files with the `FileReaderService`.

* Extract `ChunkBufferStore` class to store the buffers for each `Path`.
* Add `hashCode()` and `equals()` to `ChunkReader` and dependent classes so we can use `ChunkReader` in a `Set`.
* Adjust `FileNamingStrategy` classes to operate on a `Set<Path>`.
* Let `FileObserver` watch multiple files for each directory.
* Adjust `FileReaderService` to follow multiple files.